### PR TITLE
将lab1.2和lab1.3中的图片从相对路经表示转换为存储于SM.MS图床上，修复了github上无法直接显示图片的问题

### DIFF
--- a/labs/lab_1/lab_1_2.md
+++ b/labs/lab_1/lab_1_2.md
@@ -9,47 +9,47 @@
 
 1. 打开 Visual Studio 2019 Preview Community (点击 continue without codes)
 
-![open VS](pix/splashVS.PNG)
+![open VS](https://i.loli.net/2020/10/07/lDhCAU6mdFtGfQ1.png)
 
 2. 点击 File -> new -> Project
 
-![new project](pix/newProject.PNG)
+![new project](https://i.loli.net/2020/10/07/mJ8kPI7gAfydpcQ.png)
 
 3. 在 Create a new project 对话框的右上下拉选择菜单种分别选择 [c++], 
 [Windows], [WinUI], 再在出现的项目类型中选择 "Blank App (WinUI in UWP)"
 后点击 Next
 
-![create a new project](pix/createApp.PNG)
+![create a new project](https://i.loli.net/2020/10/07/lSszhNgcCk4BPR8.png)
 
 上面的应用程序类型可根据需要选择其它项目类型。
 
 4. 填写欲创建的工程名称、存放位置及解决方案名称后点击 Create 按钮
 
-![Config the new project](pix/configProject.PNG)
+![Config the new project](https://i.loli.net/2020/10/07/FHOVX9PorTlJQf3.png)
 
 5. 选择目标应用程序运行的平台版本后点击 OK
 
-![Select the target platform](pix/choosePlatform.PNG)
+![Select the target platform](https://i.loli.net/2020/10/07/SXTLIQsco7UHlmu.png)
 
 6. 然后等待...
 
-![Creating project](pix/creating.PNG)
+![Creating project](https://i.loli.net/2020/10/07/mtCTz19PUAFyHGf.png)
 
 7. 最终生成应用程序工程
 
-![the generated project](pix/projectGenerated.PNG)
+![the generated project](https://i.loli.net/2020/10/07/lUaEIRi4TvmoFzL.png)
 
 8. 选择 active solution platform 为 x64
 
-![config active solution platform to be x64](pix/activeSolutionPlatform.PNG)
+![config active solution platform to be x64](https://i.loli.net/2020/10/07/Ggd1PpexVuLYUl6.png)
 
 9. 右键点击项目名称后在弹出的菜单里选择 build 开始生成该项目的应用
 
-![build the project](pix/buildProject.PNG)
+![build the project](https://i.loli.net/2020/10/07/mVKAdE6OqQJjp4i.png)
 
 10. 按快捷键 F5 可调试运行该程序
 
-![Press shortcut F5 to run](pix/runDebug.PNG)
+![Press shortcut F5 to run](https://i.loli.net/2020/10/07/1AFk7xZs9RHroeD.png)
 
 第一次运行会比较慢，请耐心等待。
 

--- a/labs/lab_1/lab_1_3.md
+++ b/labs/lab_1/lab_1_3.md
@@ -16,24 +16,24 @@
 
 1. 设置 Active solution configuration 为 Release
 
-![set active config](pix/activeConfig.PNG)
+![set active config](https://i.loli.net/2020/10/07/QLkVA6MpPznxOwY.png)
 
 2. 右击项目名称点击 Build 生成目标应用程序（参照上个实验）
 
 3. Right-click the project and choose Publish->Create App Packages
 
-![Create App Package...](pix/publish.PNG)
+![Create App Package...](https://i.loli.net/2020/10/07/rREzf5JigKjqMCh.png)
 
 4. Select Sideloading in the first page of the wizard and then click Next
 
-![Select distribution method](pix/distributionMethod.PNG)
+![Select distribution method](https://i.loli.net/2020/10/07/q9hTYeGA2vtcUkN.png)
 
 5. On the Select signing method page, select whether to skip packaging 
 signing or select a certificate for signing. You can create a 
 new certificate. For an MSIX package to be installed on an end user's 
 machine, it must be signed with a cert that is trusted on the machine.
 
-![Select signing method](pix/signingMethod.PNG)
+![Select signing method](https://i.loli.net/2020/10/07/69FkBsQ7JXwhyMm.png)
 
 Here we click "Create..." button to create a test certificate:
 
@@ -41,46 +41,46 @@ Here we click "Create..." button to create a test certificate:
 
 Press the button "OK" will then return to the Select signing method page:
 
-![done creating test certificate](pix/doneSigningMethod.PNG)
+![done creating test certificate](https://i.loli.net/2020/10/07/8rbSwtKfFA3XLJC.png)
 
 6. Complete the Select and configure packages page
 
-![Select and configure packages](pix/sel_n_config_pack.PNG)
+![Select and configure packages](https://i.loli.net/2020/10/07/wpjCv9gY25VWbTO.png)
 
 7. Input in the UNC path a local folder of your computer to store the package,
 and then click the Create button
 
-![input an UNC path](pix/UNC_path.PNG)
+![input an UNC path](https://i.loli.net/2020/10/07/c42EWHCDpUAelxz.png)
 
 here we input "file:///F:/tmp"
 
 8. click "copy and close" to generate the install package
 
-![copy and close](pix/copy_n_close.PNG)
+![copy and close](https://i.loli.net/2020/10/07/W1zMJr6w9xbjvEq.png)
 
 9. 现在在第7步你所输入的 UNC 路径下（这里是F:\tmp）生成了安装包，但因为安装证书
 还未注册而不能使用。
 
-![folder of the installation package](pix/folderUNC.PNG)
+![folder of the installation package](https://i.loli.net/2020/10/07/MVscIyPmXSewoFf.png)
 
 下面我们将第5步创建的测试证书进行注册（我们把前述的UNC路径称为安装包路径）：
 * 打开安装包路径，进入下面的一个文件夹（这里是 winuiTest_1.0.2.0_Test）
 * 该文件夹里有一个 winuiTest_1.0.2.0_x64.msixbundle 文件，右击并点击属性
 
-![msix attribution](pix/msixAttrib.PNG)
+![msix attribution](https://i.loli.net/2020/10/07/OE7jhzpefJo4YV9.png)
 
 点击“数字签名”标签页后点击签名列表中的签名，然后再点依次击详细信息、查看证书、安装
 证书：
 
-![install certificate](pix/installCert.PNG)
+![install certificate](https://i.loli.net/2020/10/07/Gxf34dK1OlYVo75.png)
 
 在证书向导里点击“本地计算机”后单击下一步：
 
-![local machine](pix/certImport.PNG)
+![local machine](https://i.loli.net/2020/10/07/RL392UAi4ThGD8O.png)
 
 选择将所有证书都放入下列存储后再点击浏览，然后选择“受信任的根证书颁发机构”后点确定：
 
-![save certificate](pix/saveCert.PNG)
+![save certificate](https://i.loli.net/2020/10/07/ZW6PjEd5lzrY1mQ.png)
 
 确定后点击下一步就可将证书安装到系统中。大家可以按实验开始前的子实验中的方法查看证书
 是否正确安装。
@@ -91,5 +91,5 @@ here we input "file:///F:/tmp"
 请先把应用程序卸载，再双击winuiTest.appinstaller即可完成安装。
 安装完成后在开始菜单里就可以看到所安装的程序，点击可以启动运行：
 
-![start menu](pix/winStart.PNG)
+![start menu](https://i.loli.net/2020/10/07/HbRPI6U4YqeuL1v.png)
 


### PR DESCRIPTION
将lab1.2和lab1.3中的图片从相对路经表示转换为存储于SM.MS图床上
修复了githubusercontent无法在境内打开从而github网页上无法直接显示图片的问题